### PR TITLE
added precompled header and tested

### DIFF
--- a/Chinatsu/Chinatsu.vcxproj
+++ b/Chinatsu/Chinatsu.vcxproj
@@ -76,7 +76,8 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>cnpch.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>CN_PLATFORM_WINDOWS;CN_BUILD_DLL;CN_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>src;vendor\spdlog\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -98,7 +99,8 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>cnpch.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>CN_PLATFORM_WINDOWS;CN_BUILD_DLL;CN_RELEASE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>src;vendor\spdlog\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -124,7 +126,8 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Dist|x64'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>cnpch.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>CN_PLATFORM_WINDOWS;CN_BUILD_DLL;CN_DIST;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>src;vendor\spdlog\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -158,10 +161,14 @@
     <ClInclude Include="src\Chinatsu\Events\KeyEvent.h" />
     <ClInclude Include="src\Chinatsu\Events\MouseEvent.h" />
     <ClInclude Include="src\Chinatsu\Log.h" />
+    <ClInclude Include="src\cnpch.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\Chinatsu\Application.cpp" />
     <ClCompile Include="src\Chinatsu\Log.cpp" />
+    <ClCompile Include="src\cnpch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Chinatsu/Chinatsu.vcxproj.filters
+++ b/Chinatsu/Chinatsu.vcxproj.filters
@@ -34,6 +34,7 @@
     <ClInclude Include="src\Chinatsu\Log.h">
       <Filter>Chinatsu</Filter>
     </ClInclude>
+    <ClInclude Include="src\cnpch.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\Chinatsu\Application.cpp">
@@ -42,5 +43,6 @@
     <ClCompile Include="src\Chinatsu\Log.cpp">
       <Filter>Chinatsu</Filter>
     </ClCompile>
+    <ClCompile Include="src\cnpch.cpp" />
   </ItemGroup>
 </Project>

--- a/Chinatsu/src/Chinatsu/Application.cpp
+++ b/Chinatsu/src/Chinatsu/Application.cpp
@@ -1,3 +1,4 @@
+#include "cnpch.h"
 #include "Application.h"
 
 #include "Chinatsu/Events/ApplicationEvent.h"

--- a/Chinatsu/src/Chinatsu/Events/ApplicationEvent.h
+++ b/Chinatsu/src/Chinatsu/Events/ApplicationEvent.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Event.h"
-#include <sstream>
 
 namespace Chinatsu
 {

--- a/Chinatsu/src/Chinatsu/Events/Event.h
+++ b/Chinatsu/src/Chinatsu/Events/Event.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "cnpch.h"
 #include "Chinatsu/Core.h"
 
 namespace Chinatsu {

--- a/Chinatsu/src/Chinatsu/Events/Event.h
+++ b/Chinatsu/src/Chinatsu/Events/Event.h
@@ -2,9 +2,6 @@
 
 #include "Chinatsu/Core.h"
 
-#include <string>
-#include <functional>
-
 namespace Chinatsu {
 
 	// Events in Chinatsu are currently blocking, meaning when an event occurs it

--- a/Chinatsu/src/Chinatsu/Events/KeyEvent.h
+++ b/Chinatsu/src/Chinatsu/Events/KeyEvent.h
@@ -1,8 +1,6 @@
 #pragma once
 #include "Event.h"
 
-#include <sstream>
-
 namespace Chinatsu
 {
 	class CHINATSU_API KeyEvent : public Event

--- a/Chinatsu/src/Chinatsu/Events/MouseEvent.h
+++ b/Chinatsu/src/Chinatsu/Events/MouseEvent.h
@@ -2,8 +2,6 @@
 
 #include "Event.h"
 
-#include <sstream>
-
 namespace Chinatsu 
 {
 	class CHINATSU_API MouseMovedEvent : public Event

--- a/Chinatsu/src/Chinatsu/Log.cpp
+++ b/Chinatsu/src/Chinatsu/Log.cpp
@@ -1,3 +1,4 @@
+#include "cnpch.h"
 #include "Log.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 namespace Chinatsu

--- a/Chinatsu/src/Chinatsu/Log.h
+++ b/Chinatsu/src/Chinatsu/Log.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <memory>
-
 #include "Core.h"
 #include "spdlog/spdlog.h"
 #include "spdlog/fmt/ostr.h"

--- a/Chinatsu/src/cnpch.cpp
+++ b/Chinatsu/src/cnpch.cpp
@@ -1,0 +1,1 @@
+#include "cnpch.h"

--- a/Chinatsu/src/cnpch.h
+++ b/Chinatsu/src/cnpch.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <iostream>
+#include <memory>
+#include <utility>
+#include <algorithm>
+#include <functional>
+
+#include <string>
+#include <sstream>
+#include <vector>
+#include <unordered_map>
+#include <unordered_set>
+
+
+#ifdef CN_PLATFORM_WINDOWS
+	#include <Windows.h>
+#endif
+

--- a/premake5.lua
+++ b/premake5.lua
@@ -18,6 +18,9 @@ project "Chinatsu"
 	-- dir for output
 	targetdir ("bin/" .. outputdir .. "/%{prj.name}")
 	objdir ("bin-int/" .. outputdir .. "/%{prj.name}")
+
+	pchheader "cnpch.h"
+	pchsource "Chinatsu/src/cnpch.cpp"
 	
 	files
 	{


### PR DESCRIPTION
This pull request introduces changes to the `Chinatsu` project to implement precompiled headers for improved compilation times. The most important changes include modifications to the project files to use the precompiled header, updates to the source files to include the precompiled header, and the addition of the precompiled header source and header files.

Changes to project files:

* [`Chinatsu/Chinatsu.vcxproj`](diffhunk://#diff-ee90d48c7255ee8b82dd40b9b7c7e157affd3a22fe1a89576f6eea2fb99f9073L79-R80): Updated the project configuration to use precompiled headers and added references to the precompiled header file `cnpch.h` and its source file `cnpch.cpp`. [[1]](diffhunk://#diff-ee90d48c7255ee8b82dd40b9b7c7e157affd3a22fe1a89576f6eea2fb99f9073L79-R80) [[2]](diffhunk://#diff-ee90d48c7255ee8b82dd40b9b7c7e157affd3a22fe1a89576f6eea2fb99f9073L101-R103) [[3]](diffhunk://#diff-ee90d48c7255ee8b82dd40b9b7c7e157affd3a22fe1a89576f6eea2fb99f9073L127-R130) [[4]](diffhunk://#diff-ee90d48c7255ee8b82dd40b9b7c7e157affd3a22fe1a89576f6eea2fb99f9073R164-R171)
* [`Chinatsu/Chinatsu.vcxproj.filters`](diffhunk://#diff-f6402d156a29d0a032e3835007137d20af6ebabac0e9b074e78faf72c2a9c13cR37): Added filters for the precompiled header files. [[1]](diffhunk://#diff-f6402d156a29d0a032e3835007137d20af6ebabac0e9b074e78faf72c2a9c13cR37) [[2]](diffhunk://#diff-f6402d156a29d0a032e3835007137d20af6ebabac0e9b074e78faf72c2a9c13cR46)
* [`premake5.lua`](diffhunk://#diff-305eff9084f83e9096ab2d18b9815c7b52c4d3603363d3d6a27e1c85f466ec45R22-R24): Set `cnpch.h` as the precompiled header and `cnpch.cpp` as the precompiled header source.

Updates to source files:

* `Chinatsu/src/Chinatsu/Application.cpp`, `Chinatsu/src/Chinatsu/Log.cpp`, `Chinatsu/src/Chinatsu/Events/Event.h`: Included the precompiled header `cnpch.h`. [[1]](diffhunk://#diff-4afe993ebf51c1eb7ee5b3815bea093f8888492dd38eb03a6b45394a222285e7R1) [[2]](diffhunk://#diff-fce469eabf32837ddf03162f601204e7f601da80ea1df639c493de32b4e5dc8dR1) [[3]](diffhunk://#diff-419d1a5101c7571b91ce3b32e6637eb0f7d711f1b12564a84ab27ee650f9ad44R3-L7)

Addition of precompiled header files:

* [`Chinatsu/src/cnpch.cpp`](diffhunk://#diff-506b8ae72956626192e5acd439f236c289ab3e6ada34e7e4a0c1303ca7e1e293R1): Added the precompiled header source file.
* [`Chinatsu/src/cnpch.h`](diffhunk://#diff-943ced266c2452fb74cd004f884c792f6566ea4f9776ad0b092fd40979941878R1-R19): Added the precompiled header file with necessary includes.